### PR TITLE
Fix aspect ratio on kiosk avatars

### DIFF
--- a/static/kiosk.css
+++ b/static/kiosk.css
@@ -11,8 +11,8 @@ h1,h2,h3 {margin-top:0;margin-bottom:.5em}
 .sectionhead {border-bottom:1px solid #ccc;}
  
 .staffline {clear:both; padding-top:1.0em; height:80px;}
-.staffline .pic {height:72px; width:52px;margin:1px; float:left; margin-right:8px; }
-.staffline .picbox {border:1px solid #ccc; width:54px; height:74px; float:left; margin-right:10px}
+.staffline .pic {height:72px; width:72px;margin:1px; float:left; margin-right:8px; }
+.staffline .picbox {border:1px solid #ccc; width:74px; height:74px; float:left; margin-right:10px}
 .staffline .name {font-size:150%; margin-top:6px}
 .staffline .email {margin-top:.5em; color:#777; font-size:75%;}
 .staffline .ago {margin-top:.5em; font-size:75%; color:#777}


### PR DESCRIPTION
It used to compensate for scaling from 4:3 to 16:9 by the TV, but now
that's the TV is driven by HDMI the avatars should be square.
